### PR TITLE
* make it work with Spring Security 4.0.0.RC2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<org.springframework-version>4.1.3.RELEASE</org.springframework-version>
 		 <!--<org.springframework-version>4.0.6.BUILD-SNAPSHOT</org.springframework-version>-->
 		<!--<org.springframework-version>4.0.5.RELEASE</org.springframework-version>-->
-		<org.springframework.security-version>4.0.0.RC1</org.springframework.security-version>
+		<org.springframework.security-version>4.0.0.RC2</org.springframework.security-version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/springframework/samples/portfolio/config/WebSocketSecurityConfig.java
+++ b/src/main/java/org/springframework/samples/portfolio/config/WebSocketSecurityConfig.java
@@ -16,8 +16,6 @@
 package org.springframework.samples.portfolio.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.SimpMessageType;
-import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 
@@ -30,10 +28,17 @@ public class WebSocketSecurityConfig extends AbstractSecurityWebSocketMessageBro
     @Override
     protected void configureInbound(MessageSecurityMetadataSourceRegistry messages) {
         messages
-            .antMatchers(SimpMessageType.MESSAGE,"/queue/**","/topic/**").denyAll()
-            .antMatchers(SimpMessageType.SUBSCRIBE, "/queue/**/*-user*","/topic/**/*-user*").denyAll()
-            .antMatchers("/user/queue/errors").permitAll()
-            .anyMessage().hasRole("USER");
+                .simpMessageDestMatchers("/queue/**", "/topic/**").denyAll()
+                .simpSubscribeDestMatchers("/queue/**/*-user*", "/topic/**/*-user*").denyAll()
+                .simpDestMatchers("/user/queue/errors").permitAll()
+                .anyMessage().hasRole("USER");
+
 
     }
+
+    @Override
+    protected boolean sameOriginDisabled() {
+        return true;
+    }
+
 }


### PR DESCRIPTION
Updating Spring Security to latest 4.0.0.RC2 version breaks the application. These changes fix WebSocketSecurityConfig compilation and resolve issue with MissingCsrfTokenException.
